### PR TITLE
Fix minor bug that affects HTML markup when a collection's Note Title…

### DIFF
--- a/Sources/NotenikUtils/utils/Markedup.swift
+++ b/Sources/NotenikUtils/utils/Markedup.swift
@@ -1063,30 +1063,6 @@ public class Markedup: CustomStringConvertible {
         emphasisPending = 0
     }
     
-    public func startItalics() {
-        switch format {
-        case .htmlFragment, .htmlDoc, .xhtmlDoc, .netscapeBookmarks:
-            append("<i>")
-        case .markdown:
-            append("*")
-        case .opml:
-            break
-        }
-        emphasisPending = 1
-    }
-    
-    public func finishItalics() {
-        switch format {
-        case .htmlFragment, .htmlDoc, .xhtmlDoc, .netscapeBookmarks:
-            append("</i>")
-        case .markdown:
-            append("*")
-        case .opml:
-            break
-        }
-        emphasisPending = 0
-    }
-    
     public func startCite(klass: String? = nil) {
         switch format {
         case .htmlFragment, .htmlDoc, .xhtmlDoc, .netscapeBookmarks:
@@ -1196,7 +1172,7 @@ public class Markedup: CustomStringConvertible {
                     finishStrong()
                 }
                 if italic {
-                    finishItalics()
+                    finishEmphasis()
                 }
                 finishParagraph()
             } else {


### PR DESCRIPTION
When a collection's Note Title Display preference is set to either "p italic" or "p bold and italic" this results in the note's body being displayed in italics along with the paragraph element that substitutes for the standard HTML header levels when `headingLevel == 0`. I think this minor change may fix the issue. I also removed the offending `startItalics`/`finishItalics` function in hopes that it would ensure parity with the rest of the code and the resulting HTML markup.